### PR TITLE
fixes compile bug from hard-coded header path

### DIFF
--- a/include/RootManager.hh
+++ b/include/RootManager.hh
@@ -12,10 +12,11 @@ using namespace std ;
 //ROOT
 #include<TFile.h>
 #include<TH1.h>
+#include "TTree.h"
 
 //User
 #include "RawG4Event.hh"
-#include "/opt/DetectorSimulations/detectorSimulations/dataRootClass/TSpiceData.h"
+#include "../dataRootClass/TSpiceData.h"
 
 class RootManager   {
     


### PR DESCRIPTION
Addresses some of the changes recommended by @moukaddam in issue #66.  Didn't change the RawEventClass despite recommendation since this was not required for compile.  Ultimately headers should probably all make their way into the include directory - but one battle at a time here.

Code now compiles on alphadon.
