### PR TITLE
disable Sensitive Detector for Spice (SiLi), fixed bugs in segment naming...

### DIFF
--- a/include/DetectionSystemSpice.hh
+++ b/include/DetectionSystemSpice.hh
@@ -52,11 +52,10 @@ public:
 private:
   G4AssemblyVolume* assembly;
   G4AssemblyVolume* assemblySiRing[10];
-  SensitiveDetector* siDetSpiceRing_SD[10];
 
   
 public:
-  G4int Build(G4SDManager* mySDman);
+  G4int Build();
   G4int PlaceDetector(G4LogicalVolume* exp_hall_log, G4ThreeVector move,
 		      G4int ringNumber, G4int nRadSeg, G4int detectorNumber);
   G4int PlaceGuardRing(G4LogicalVolume* exp_hall_log, G4ThreeVector move);
@@ -74,35 +73,35 @@ private:
   // OBS: crystal properties are public, others are private
   //--------------------------------------------------------//
 private:
-  G4String wafer_material;
+  G4String 	wafer_material;
   
   //-----------------------------//
   // parameters for the annular  //
   // planar detector crystal     //
   //-----------------------------//
 public:
-  G4double siDetCrystalThickness;
-  G4double siDetCrystalOuterDiameter;
-  G4double siDetCrystalInnerDiameter;
-  G4double siDetRadialSegments;
-  G4double siDetPhiSegments;
+  G4double 	siDetCrystalThickness;
+  G4double 	siDetCrystalOuterDiameter;
+  G4double 	siDetCrystalInnerDiameter;
+  G4double 	siDetRadialSegments;
+  G4double 	siDetPhiSegments;
 
   //-------------------------------//
   // parameters for the guard ring //
   //-------------------------------//
 private:
-  G4double siDetGuardRingInnerDiameter;
-  G4double siDetGuardRingOuterDiameter;
+  G4double 	siDetGuardRingInnerDiameter;
+  G4double 	siDetGuardRingOuterDiameter;
    
     //------------------------------------------------//
     // internal methods in Build()
     //------------------------------------------------//
 private:
-  G4int BuildSiliconWafer(G4int ringID);
-  G4int BuildInnerGuardRing();
-  G4int BuildOuterGuardRing();
+  G4int 	BuildSiliconWafer(G4int ringID);
+  G4int 	BuildInnerGuardRing();
+  G4int 	BuildOuterGuardRing();
   
-  G4Tubs*             BuildCrystal(G4int myRingID);
+  G4Tubs*	BuildCrystal(G4int myRingID);
 };
 
 #endif

--- a/include/SteppingAction.hh
+++ b/include/SteppingAction.hh
@@ -55,10 +55,14 @@ private:
   DetectorConstruction* detector;
   EventAction*          eventaction;  
 
+  // Griffin
   void SetDetAndCryNumberForGriffinComponent( G4String );
   void SetDetAndCryNumberForDeadLayerSpecificGriffinCrystal(G4String);
   void SetDetNumberForGenericDetector( G4String );
-
+  
+  //Spice
+  void SetDetAndCryNumberForSpiceDetector( G4String ) ;
+  
   G4int FindTrueGriffinDetector(G4int);
 
   G4int stepNumber;

--- a/src/DetectorConstruction.cc
+++ b/src/DetectorConstruction.cc
@@ -34,7 +34,6 @@
 
 #include "DetectorConstruction.hh"
 #include "DetectorMessenger.hh"
-#include "SensitiveDetector.hh"
 #include "G4RunManager.hh"
 
 #include "G4Material.hh"
@@ -729,22 +728,22 @@ void DetectorConstruction::AddDetectionSystemSceptar(G4int ndet)
 
 void DetectorConstruction::AddDetectionSystemSpice(G4int nRings)
 {
-	G4SDManager* mySDman = G4SDManager::GetSDMpointer();
+
 	DetectionSystemSpice* pSpice = new DetectionSystemSpice() ;
-	pSpice->Build(mySDman); 
+	pSpice->Build(); 
 	
-  G4int nPhiSeg = 12;
-  G4int detID=0;
+  G4int NumberSeg = 12; // Segments in Phi
+  G4int segmentID=0;
   G4double annularDetectorDistance = 115*mm /*+ 150*mm*/;
   G4ThreeVector pos(0,0,-annularDetectorDistance); 
   pSpice->PlaceGuardRing(logicWorld, pos);
   for(int ring = 0; ring<nRings; ring++)
     {
-      for(int radSeg=0; radSeg<nPhiSeg; radSeg++)
+      for(int Seg=0; Seg<NumberSeg; Seg++)
 		{
-		  pSpice->PlaceDetector(logicWorld, pos, ring+1, radSeg, detID);
-		  detID++;
-		} // end for(int radSeg=0; radSeg<nPhiSeg; radSeg++)
+		  pSpice->PlaceDetector(logicWorld, pos, ring, Seg, segmentID);
+		  segmentID++;
+		} // end for(int Seg=0; Seg<NumberSeg; Seg++)
     } // end for(int ring = 0; ring<nRings; ring++)
 }
 
@@ -754,18 +753,18 @@ void DetectorConstruction::AddDetectionSystemS3(G4int nRings)
 	DetectionSystemS3* pS3 = new DetectionSystemS3();
 	pS3->Build(mySDman);
 	
-  G4int nPhiSeg = 32;
+  G4int NumberSeg = 32;
   G4int detID=0;
   G4double S3DetectorDistance = 21*mm /*+ 150*mm*/;
   G4ThreeVector pos(0,0,S3DetectorDistance); 
   pS3->PlaceGuardRing(logicWorld, pos);
   for(int ring = 0; ring<nRings; ring++)
 	{
-		for(int radSeg=0; radSeg<nPhiSeg; radSeg++)
+		for(int Seg=0; Seg<NumberSeg; Seg++)
 		{
-			pS3->PlaceDetector(logicWorld, pos, ring+1, radSeg, detID);
+			pS3->PlaceDetector(logicWorld, pos, ring+1, Seg, detID);
 			detID++;
-		} // end for(int radSeg=0; radSeg<nPhiSeg; radSeg++)
+		} // end for(int Seg=0; Seg<NumberSeg; Seg++)
 	} // end for(int ring = 0; ring<nRings; ring++)
 }
 

--- a/src/EventAction.cc
+++ b/src/EventAction.cc
@@ -44,7 +44,6 @@
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
 //G4
-#include "SensitiveDetector.hh"
 #include "EventAction.hh"
 #include "RunAction.hh"
 #include "G4Event.hh"
@@ -90,14 +89,44 @@ void EventAction::BeginOfEventAction(const G4Event* evt)
 
 void EventAction::EndOfEventAction(const G4Event*)
 {
+        G4double eventNumber = 0 ;
+        G4double stepNumber = 0;
+        G4double cryNumber  = 0;
+        G4double detNumber  = 0;
+        G4double depEnergy  = 0;
+        G4double posx       = 0;
+        G4double posy       = 0;
+        G4double posz       = 0;
+        G4double time       = 0;
+                
     for(G4int i = 0; i < MAXSTEPS; i++) {
-        if(stepTracker[1][i] !=0 && histoManager->GetStepTrackerBool()) {
-            histoManager->FillNtuple(stepTracker[0][i], stepTracker[1][i], stepTracker[2][i], stepTracker[3][i], stepTracker[4][i]/keV, stepTracker[5][i]/mm, stepTracker[6][i]/mm, stepTracker[7][i]/mm, stepTracker[8][i]/second );
-            RootManager::instance()->FillG4Hit(1., 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);	   // this is one hit of a Hit Collection
-            //RootManager::instance()->FillHist(1000/keV);		//optionale
+       
+        if(stepTracker[1][i] != 0 && histoManager->GetStepTrackerBool()) {
+
+        eventNumber = stepTracker[0][i] ;
+        stepNumber = stepTracker[1][i];
+        cryNumber  = stepTracker[2][i];
+        detNumber  = stepTracker[3][i];
+        depEnergy  = stepTracker[4][i];
+        posx       = stepTracker[5][i]/mm;
+        posy       = stepTracker[6][i]/mm;
+        posz       = stepTracker[7][i]/mm;
+        time       = stepTracker[8][i]/second;
+            
+        histoManager->FillNtuple(eventNumber, stepNumber, cryNumber, detNumber, depEnergy, posx, posy, posz, time );
+        /*    
+		detnum*100+segnum = key, // detnum = radius Segnum = phi     
+		pdg,
+		edep,
+		posA.x()/mm, posA.y()/mm, posA.z()/mm,
+		OriginID, OriginPdg, OriginEnergy,                  
+		OriginMoment.x(), OriginMoment.y(), OriginMoment.z()
+        */
+        RootManager::instance()->FillG4Hit(detNumber*100+cryNumber, 11, depEnergy, posx, posy, posz, 0, 11, 0, 0, 0, 0);	   // this is one hit of a Hit Collection
+        //RootManager::instance()->FillHist(1000/keV);		//optionale
         }
-        
-		if (1) { // if condition satisfied 
+
+		if (depEnergy>0 &&  detNumber<12) { // if condition satisfied 
 		RootManager::instance()->SortEvent(); // Sort the HitCollection and make a physical event 
 		}
 		

--- a/src/HistoManager.cc
+++ b/src/HistoManager.cc
@@ -43,7 +43,7 @@ HistoManager::HistoManager()
   fileName[0] = "g4out";
   factoryOn = false;
 
-  stepTrackerBool = false;
+  stepTrackerBool = true;
 
   makeHistoIndex = 0;
 


### PR DESCRIPTION
The SensitiveDetector was only used in SPICE and S3 for "historical reasons".
- I disabled it for SPICE, (next thing for the S3)
- Fixed a naming bug
- Filled the Tree for the first time, I still need to check one or two things to make sure everything is ok
- From now on the convention for counting sector/ring in the spice project start from "0"
